### PR TITLE
add margin to SHOP NOW button

### DIFF
--- a/src/css/mobal.css
+++ b/src/css/mobal.css
@@ -110,6 +110,7 @@
 .mobile-shop-btn {
   display: flex;
   justify-content: center;
+  margin-bottom: 40px;
 }
 
 .modal-icon-close {


### PR DESCRIPTION
The button "SHOP NOW" is pressed against the bottom edge of the modal window. I fixed it in this way:
margin-bottom: 40px
